### PR TITLE
Fix #2: Update deprecated gemini-pro endpoint

### DIFF
--- a/lambda/lambda_function.py
+++ b/lambda/lambda_function.py
@@ -24,7 +24,7 @@ logger.setLevel(logging.INFO)
 
 GOOGLE_API_KEY = os.getenv('GOOGLE_API_KEY')
 # API endpoint URL
-url = "https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key={}".format(GOOGLE_API_KEY)
+url = "https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-pro-preview:generateContent?key={}".format(GOOGLE_API_KEY)
 # Headers for the request
 headers = {
     'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- Replace the deprecated `gemini-pro` model in the Gemini Developer API URL with `gemini-3.1-pro-preview`, which is the cause of the `Request error` reported in #2.

## Root cause
`lambda/lambda_function.py` calls `https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent`. The `gemini-pro` alias is retired on the v1beta endpoint, so every `requests.post` returns a non-200 status and the handler falls through to `speak_output = "Request error"`.

## Verification
Live-tested the new endpoint with the lambda's exact URL pattern and payload shape:

```
POST https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-pro-preview:generateContent?key=...
{"contents":[{"role":"user","parts":[{"text":"Hello! Respond in English clearly and do not be verbose. OK?"}]}]}
```

Returned HTTP 200 with `candidates[0].content.parts[0].text` populated — matching the response parser at `lambda/lambda_function.py:55-58`.

## Test plan
- [ ] Set `GOOGLE_API_KEY` in the Lambda env to a valid AI Studio key.
- [ ] Invoke the skill (LaunchRequest) and confirm a greeting is returned instead of "Request error".
- [ ] Send a follow-up `ChatIntent` utterance and confirm a model reply is spoken.

Fixes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)